### PR TITLE
support logs ingestion from GCP organization

### DIFF
--- a/modules/logging_organizations/main.tf
+++ b/modules/logging_organizations/main.tf
@@ -1,0 +1,9 @@
+resource "google_logging_organization_sink" "scdm_data_logging_sinks" {
+    for_each = toset(var.data_organizations)
+    org_id = each.key
+    name = var.logging_name
+    description = "organization aggregated sink"
+    destination = "pubsub.googleapis.com/${var.pubsub_topic}"
+    filter = var.filter
+    include_children = true
+}

--- a/modules/logging_organizations/outputs.tf
+++ b/modules/logging_organizations/outputs.tf
@@ -1,0 +1,3 @@
+output "writer_identity_members" {
+  value = values(google_logging_organization_sink.scdm_data_logging_sinks)[*].writer_identity
+}

--- a/modules/logging_organizations/variables.tf
+++ b/modules/logging_organizations/variables.tf
@@ -1,0 +1,19 @@
+variable "data_organizations" {
+    description = "gcp organizations that will sink logs"
+    type = list(string)
+}
+
+variable "logging_name" {
+    description = "Sink Logging Router name"
+    type = string
+}
+
+variable "pubsub_topic" {
+    description = "Pubsub topic for logging"
+    type = string
+}
+
+variable "filter" {
+    description = "Filter for the logging router"
+    type = string
+}

--- a/modules/logging_projects/main.tf
+++ b/modules/logging_projects/main.tf
@@ -1,0 +1,8 @@
+resource "google_logging_project_sink" "scdm_data_logging_sinks" {
+    for_each = toset(var.data_projects)
+    project = each.key
+    name = var.logging_name
+    destination = "pubsub.googleapis.com/${var.pubsub_topic}"
+    filter = var.filter
+    unique_writer_identity = true
+}

--- a/modules/logging_projects/outputs.tf
+++ b/modules/logging_projects/outputs.tf
@@ -1,0 +1,3 @@
+output "writer_identity_members" {
+  value = values(google_logging_project_sink.scdm_data_logging_sinks)[*].writer_identity
+}

--- a/modules/logging_projects/variables.tf
+++ b/modules/logging_projects/variables.tf
@@ -1,0 +1,19 @@
+variable "data_projects" {
+    description = "Non-centralized gcp projects"
+    type = list(string)
+}
+
+variable "logging_name" {
+    description = "Sink Logging Router name"
+    type = string
+}
+
+variable "pubsub_topic" {
+    description = "Pubsub topic for logging"
+    type = string
+}
+
+variable "filter" {
+    description = "Filter for the logging router"
+    type = string
+}

--- a/modules/organization_iam_binding/main.tf
+++ b/modules/organization_iam_binding/main.tf
@@ -1,0 +1,22 @@
+resource "google_organization_iam_custom_role" "scdm_readonly_role" {
+  for_each    = toset(var.source_organizations)
+  org_id       = each.key
+  role_id     = var.role_id
+  title       = var.role_title
+  description = var.role_description
+  permissions = var.roles_list
+}
+
+locals {
+  role_ids = {for k, v in google_organization_iam_custom_role.scdm_readonly_role : "${k}" => v.id }
+}
+
+
+resource "google_organization_iam_binding" "scdm_service_account_binding_with_readonly_role" {
+  for_each = toset(var.source_organizations)
+  org_id  = each.key
+  role     = lookup(local.role_ids, "${each.key}")
+  members = [
+    "serviceAccount:${var.service_account_email}",
+  ]
+}

--- a/modules/organization_iam_binding/outputs.tf
+++ b/modules/organization_iam_binding/outputs.tf
@@ -1,0 +1,20 @@
+#Added for unit testing of the module
+output "custom_role_id" {
+value = values(google_organization_iam_custom_role.scdm_readonly_role)[*].role_id
+}
+
+output "custom_role_title" {
+value = values(google_organization_iam_custom_role.scdm_readonly_role)[*].title
+}
+
+output "IAM_binding_service_account" {
+value = values(google_organization_iam_binding.scdm_service_account_binding_with_readonly_role)[*].members
+
+}
+
+output "IAM_binding_service_account_role" {
+value = values(google_organization_iam_binding.scdm_service_account_binding_with_readonly_role)[*].role
+}
+
+
+

--- a/modules/organization_iam_binding/variable.tf
+++ b/modules/organization_iam_binding/variable.tf
@@ -1,0 +1,29 @@
+variable "source_organizations" {
+  description = "GCP organization IDs"
+  type        = list(string)
+}
+
+variable "role_id" {
+  description = "Unique identifier for the custom role"
+  type        = string
+}
+
+variable "role_title" {
+  description = "Custom role title"
+  type        = any
+}
+
+variable "role_description" {
+  description = "Custom role description"
+  type        = string
+}
+
+variable "roles_list" {
+  description = "Define list of permissions to create custom role"
+  type        = list(string)
+}
+
+variable "service_account_email" {
+  description = "Service account email for the IAM binding"
+  type        = string
+}

--- a/modules/pubsub_topic_iam_binding/main.tf
+++ b/modules/pubsub_topic_iam_binding/main.tf
@@ -2,5 +2,5 @@ resource "google_pubsub_topic_iam_binding" "scdm_iam_binding_members" {
   project = var.project
   topic = var.pubsub_topic
   role = "roles/pubsub.publisher"
-  members = var.unique_writer_identity_members
+  members = var.writer_identity_members
 }

--- a/modules/pubsub_topic_iam_binding/variables.tf
+++ b/modules/pubsub_topic_iam_binding/variables.tf
@@ -9,7 +9,7 @@ variable "pubsub_topic" {
 }
 
 
-variable "unique_writer_identity_members" {
-  description = "Unique writer identity of the logging sink"
+variable "writer_identity_members" {
+  description = "Writer identity of the logging sink"
   type = list(string)
 }


### PR DESCRIPTION
The Terraform modules can be used for ingesting logs for either GCP projects or GCP organization. (Folders support would be added soon).
Now, the logging sinks and IAM bindings are set up based on the above.