### PR TITLE
fix folder iam bindings

### DIFF
--- a/modules/folder_iam_binding/main.tf
+++ b/modules/folder_iam_binding/main.tf
@@ -1,4 +1,5 @@
 resource "google_organization_iam_custom_role" "scdm_readonly_role" {
+  count       = (var.create_module == true) ? 1 : 0
   org_id      = var.parent_organization
   role_id     = var.role_id
   title       = var.role_title
@@ -7,14 +8,14 @@ resource "google_organization_iam_custom_role" "scdm_readonly_role" {
 }
 
 locals {
-  role_id = google_organization_iam_custom_role.scdm_readonly_role.role_id
+  role_id = google_organization_iam_custom_role.scdm_readonly_role[*].role_id
 }
 
 resource "google_folder_iam_binding" "scdm_service_account_binding_with_readonly_role" {
   for_each = toset(var.folders)
-  folder = "folders/${each.key}"
-  role   = "organizations/${var.parent_organization}/roles/${local.role_id}"
-  members = [
+  folder   = "folders/${each.key}"
+  role     = "organizations/${var.parent_organization}/roles/${local.role_id[0]}"
+  members  = [
     "serviceAccount:${var.service_account_email}",
   ]
 }

--- a/modules/folder_iam_binding/outputs.tf
+++ b/modules/folder_iam_binding/outputs.tf
@@ -1,10 +1,10 @@
 #Added for unit testing of the module
 output "custom_role_id" {
-value = google_organization_iam_custom_role.scdm_readonly_role.role_id
+value = google_organization_iam_custom_role.scdm_readonly_role[*].role_id
 }
 
 output "custom_role_title" {
-value = google_organization_iam_custom_role.scdm_readonly_role.title
+value = google_organization_iam_custom_role.scdm_readonly_role[*].title
 }
 
 output "IAM_binding_service_account" {

--- a/modules/folder_iam_binding/variable.tf
+++ b/modules/folder_iam_binding/variable.tf
@@ -32,3 +32,8 @@ variable "service_account_email" {
   description = "Service account email for the IAM binding"
   type        = string
 }
+
+variable "create_module" {
+  description = "If set to true, it will create folder iam bindings"
+  type        = bool
+}


### PR DESCRIPTION
Resources for folder iam bindings should not be created when hierarchy level is `project` or `organization`.