### PR TITLE
replace deprecated attribute path with id

### DIFF
--- a/modules/pubsub/outputs.tf
+++ b/modules/pubsub/outputs.tf
@@ -3,7 +3,7 @@ output "topic_name" {
 }
 
 output "subscription_name" {
-    value = google_pubsub_subscription.pubsub_subscription.path
+    value = google_pubsub_subscription.pubsub_subscription.id
 }
 
 #Added for the unit testing of the module


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/google/3.90.0/docs/resources/pubsub_subscription

path is deprecated in favor of id which is identical in value